### PR TITLE
Normalize the nova path by stripping leading & trailing slashes

### DIFF
--- a/src/Http/Middleware/Google2fa.php
+++ b/src/Http/Middleware/Google2fa.php
@@ -61,7 +61,7 @@ class Google2fa
 
     private function userIsAuthenticating($request): bool
     {
-        $novaPath = config('nova.path');
+        $novaPath = trim(config('nova.path'), '/') . '/';
         return $request->path() === $novaPath . 'google2fa/authenticate' || $request->path() === $novaPath . 'google2fa/register'
             || $request->path() === $novaPath . 'google2fa/recover';
     }


### PR DESCRIPTION
Previously the code assumed that the nova.path was configured correctly. This may cause someone to lose time debugging the package.